### PR TITLE
Multiple Feature Enhancements and integrations

### DIFF
--- a/api.php
+++ b/api.php
@@ -1081,7 +1081,20 @@ class SetPlayerState extends ApiEntry
 		$state = $args['state'];
 		$userID = (int)$args['userID'];
 
-		$sql = "INSERT INTO jW_PlayerStates (userID, state) VALUES (".$userID.",'".$state."');";
+		$existing = $DB->sql_row("SELECT userID, state FROM jW_PlayerStates WHERE userID = ".$userID.";");
+
+
+        try {
+            if (!$existing) {
+                $sql = "INSERT INTO jW_PlayerStates (userID, state) VALUES (".$userID.",'".$state."');";
+            } else {
+                $sql = "UPDATE jW_PlayerStates SET state = '".$state."' WHERE userID = ".$userID.";";
+            }
+        } catch (Exception $e) {
+            error_log("Failed to insert/update player state");
+            error_log(print_r($e, true));
+        }
+
 		$DB->sql_put($sql);
 		$DB->sql_put("COMMIT");
 		return "Player ".$userID." state set to ".$state."";

--- a/beta-src/src/Tournament/GameAssignment.tsx
+++ b/beta-src/src/Tournament/GameAssignment.tsx
@@ -15,6 +15,7 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import Paper from "@mui/material/Paper";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
+import RemoveIcon from '@mui/icons-material/DisabledByDefault';
 
 import {
   getGameApiRequest
@@ -44,6 +45,18 @@ const GamePlayerBox = ({gameId, gameName, players}) => {
 
   const playersToDisplay = isEmpty(players) ? [{username: "<Empty>", userID: 0}] : sortedPlayers;
 
+  const removePlayer = (playerId) => {
+    getGameApiRequest(
+      "game/leave",
+      {
+        gameID: gameId,
+        userID: playerId
+      }
+    )
+    // TODO show snackbar if successful
+    // Also may want callback prop to refresh data?
+  }
+
   return (
     <Box
       ref={drop}
@@ -68,9 +81,11 @@ const GamePlayerBox = ({gameId, gameName, players}) => {
             <ListItem
               key={player.userID}
               sx={{cursor: "default"}}
-              button
             >
               {player.username}
+              {player.username !== "<Empty>" && (
+                <RemoveIcon onClick={() => removePlayer(player.userID)} sx={{cursor: "pointer", color: "#ea9090"}} />
+              )}
             </ListItem>
           ))}
         </List>

--- a/beta-src/src/Tournament/PlayerList.tsx
+++ b/beta-src/src/Tournament/PlayerList.tsx
@@ -46,7 +46,7 @@ const PlayerList = (props) => {
 
   function cutPlayer(id, status) {
 
-    const newStatus = status === "Cut" ? "" : "Cut";
+    const newStatus = status === "Cut" ? "Active" : "Cut";
 
     getGameApiRequest(
       "player/setPlayerState",
@@ -58,7 +58,7 @@ const PlayerList = (props) => {
 
   function banPlayer(id, status) {
 
-    const newStatus = status === "Banned" ? "" : "Banned";
+    const newStatus = status === "Banned" ? "Active" : "Banned";
 
     getGameApiRequest(
       "player/setPlayerState",

--- a/beta-src/src/Tournament/endpoints.tsx
+++ b/beta-src/src/Tournament/endpoints.tsx
@@ -66,7 +66,11 @@ export async function fetchWaitingGames() {
       {hello: "world"}
     );
 
-    return waitingGames.data; // Array with IDs for all ongoing games
+    if (!waitingGames.data) {
+      console.log('waiting games data rsponse empty, debug:', waitingGames);
+    }
+
+    return waitingGames.data ? waitingGames.data : []; // Array with IDs for all ongoing games
 
   } catch(e) {
     console.log('Request to fetch ongoinggames failed, e:', e);
@@ -137,7 +141,11 @@ export async function fetchWaitingPlayers() {
       {hello: "world"}
     );
 
-    return players.data;
+    if (!players.data) {
+      console.log('waiting players data response empty, debug:', players);
+    }
+
+    return players.data ? players.data : [];
 
   } catch(e) {
     console.log('Request to fetch players failed, e:', e);

--- a/install/FullInstall/fullInstall.sql
+++ b/install/FullInstall/fullInstall.sql
@@ -1147,15 +1147,16 @@ ALTER TABLE `wD_Users`
 ADD COLUMN `mobileCountryCode` MEDIUMINT UNSIGNED NULL DEFAULT NULL AFTER `optInFeatures`,
 ADD COLUMN `mobileNumber` BIGINT UNSIGNED NULL DEFAULT NULL AFTER `mobileCountryCode`,
 ADD COLUMN `isMobileValidated` BIT NOT NULL DEFAULT 0 AFTER `mobileNumber`;
-  
+
 ALTER TABLE `wD_GameMessages` ADD `intentDeceive` VARCHAR(6);
-ALTER TABLE `wD_GameMessages` ADD `suspectedIncomingDeception` BOOLEAN;
+ALTER TABLE `wD_GameMessages` ADD `suspectedIncomingDeception` BOOLEAN; -- TODO varchar and use yes/no etc on UI
 
 CREATE TABLE jW_PlayerStates (
     userID INTEGER,
     state varchar(255) NOT NULL
-) ENGINE=InnoDB;;
+) ENGINE=InnoDB;
 
 ALTER TABLE jW_PlayerStates ADD PRIMARY KEY (userID);
 
-
+ALTER TABLE wD_Members
+  ADD score INT;

--- a/supporting-scripts/verify.mjs
+++ b/supporting-scripts/verify.mjs
@@ -41,8 +41,8 @@ async function verify() {
   try {
     const payload = await verifier.verify(tokenTarget);
 
-    // TODO access untested but we'll need it, try it out soon
     if (options.access) {
+      // TODO check payload in case we can return anything useful from there
       return {
         result: "valid"
       };


### PR DESCRIPTION
Improvements will be listed here:
- Allow admins to uncut/unban players from Tournament Dashboard > Players by toggling cut/ban icons.
- Allow admins to unassign players from game if they were drag-dropped into wrong game by mistake.
- Added missing migration to fullInstall
- Ongoing games now returns games in phases Diplomacy | Retreats | Builds. Used to only return for Diplomacy phases.
- Added ResetTournament endpoint
